### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ mkdir "$HOME/tmp";cd "$HOME/tmp"
 # Install curl
 # CentOS / RedHat - sudo dnf -y install curl
 # Ubuntu / Debian - sudo apt -y install curl
-curl -sS -o build_CCLI8.sh https://raw.githubusercontent.com/cardano-foundation/CIP-0049-polls/main/scripts/build_CCLI135.sh
+curl -sS -o build_CCLI135.sh https://raw.githubusercontent.com/cardano-foundation/CIP-0049-polls/main/scripts/build_CCLI135.sh
 chmod 755 build_CCLI135.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ mkdir "$HOME/tmp";cd "$HOME/tmp"
 # CentOS / RedHat - sudo dnf -y install curl
 # Ubuntu / Debian - sudo apt -y install curl
 curl -sS -o build_CCLI8.sh https://raw.githubusercontent.com/cardano-foundation/CIP-0049-polls/main/scripts/build_CCLI135.sh
-chmod 755 build_CCLI8.sh
+chmod 755 build_CCLI135.sh
 ```
 
 **Execute the build script**


### PR DESCRIPTION
In line 52 you are referring to the script being transferred in line 32 by the command "curl -sS -o build_CCLI8.sh https://raw.githubusercontent.com/cardano-foundation/CIP-0049-polls/main/scripts/build_CCLI8.sh ". While in line 51 by the command "curl -sS -o build_CCLI8.sh https://raw.githubusercontent.com/cardano-foundation/CIP-0049-polls/main/scripts/build_CCLI135.sh", the script being transferred is the build_CCLI135.sh, therefore it is the one that should be given the 755 privileges in line 52.