### PR TITLE
output file as build_CCLI135.sh to match later execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ mkdir "$HOME/tmp";cd "$HOME/tmp"
 # Install curl
 # CentOS / RedHat - sudo dnf -y install curl
 # Ubuntu / Debian - sudo apt -y install curl
-curl -sS -o build_CCLI8.sh https://raw.githubusercontent.com/cardano-foundation/CIP-0049-polls/main/scripts/build_CCLI135.sh
-chmod 755 build_CCLI8.sh
+curl -sS -o build_CCLI135.sh https://raw.githubusercontent.com/cardano-foundation/CIP-0049-polls/main/scripts/build_CCLI135.sh
+chmod 755 build_CCLI135.sh
 ```
 
 **Execute the build script**


### PR DESCRIPTION
2nd option still uses `build_CCLI8.sh` as output from curl of the `build_CCLI135.sh` file. Later says to run `build_CCLI135.sh`.