### PR TITLE
fix url in cardanosolutions/cardano-node link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Note: We will add to and improve this guidance and information in the first half
 To run the poll governance subcommands, a version of cardano-cli with governance poll subcommand support is required. There are a couple of options for you: 
 
 1) Checkout and build [8.0.0-untested](https://github.com/input-output-hk/cardano-node/releases/tag/8.0.0-untested) (or higher) from the [input-output-hk/cardano-node](https://github.com/input-output-hk/cardano-node) repository. 
-2) Checkout and build [release/1.35](https://github.com/CardanoSolutions/cardano-node/tree/release/1.35) from the [cardanosolutions/cardano-node](https://github.com/CardanoSolutionsCardanoSolutions/cardano-node) repository.
+2) Checkout and build [release/1.35](https://github.com/CardanoSolutions/cardano-node/tree/release/1.35) from the [cardanosolutions/cardano-node](https://github.com/CardanoSolutions/cardano-node) repository.
 3) Download pre-built binaries, for a standard Linux system
 
 ### 1) Build cardano-cli v8


### PR DESCRIPTION
The CardanoSolutions "owner" portion of the url was doubled up breaking the link.